### PR TITLE
use pd.concat instead of append (perf and warning)

### DIFF
--- a/src/pytti/ImageGuide.py
+++ b/src/pytti/ImageGuide.py
@@ -329,12 +329,10 @@ class DirectImageGuide:
                     df.index.name = "Step"
             else:
                 for j, (df, loss) in enumerate(zip(self.dataframe, losses_raw)):
-                    self.dataframe[j] = df.append(
-                        pd.DataFrame(
-                            {str(k): float(v) for k, v in loss.items()}, index=[i]
-                        ),
-                        ignore_index=False,
-                    )
+                    frames = [df] + [pd.DataFrame(
+                        {str(k): float(v) for k, v in loss.items()}, index=[i]
+                    )]
+                    self.dataframe[j] = pd.concat(frames, ignore_index=False)
                     self.dataframe[j].name = "Step"
 
         return {"TOTAL": float(total_loss)}


### PR DESCRIPTION
the use of DataFrame.append was causing a warning (it is deprecated and will be removed soon).
We use pandas.concat instead, which is future proof. Meanwhile it seems from the performance
tests I saw on the web that pandas.concat is faster than append, so we win on all plans !