### PR TITLE
feat: audio input for induced motion

### DIFF
--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -86,14 +86,20 @@ class SpectralAudioParser:
                     high_bucket += fft[i]
                     high_count += 1
             # mean energy per bucket
-            low_bucket = low_bucket / low_count
-            mid_bucket = mid_bucket / mid_count
-            high_bucket = high_bucket / high_count
+            if low_count > 0 and mid_count > 0 and high_count > 0:    
+                low_bucket = low_bucket / low_count
+                mid_bucket = mid_bucket / mid_count
+                high_bucket = high_bucket / high_count
+            else:
+                return (0,0,0)
             # normalize to [0,1] range
             max_val = np.max(fft)
-            low_bucket = low_bucket / max_val
-            mid_bucket = mid_bucket / max_val
-            high_bucket = high_bucket / max_val
-            return (low_bucket, mid_bucket, high_bucket)
+            if max_val > 0:
+                low_bucket = low_bucket / max_val
+                mid_bucket = mid_bucket / max_val
+                high_bucket = high_bucket / max_val
+            else:
+                return (0,0,0)
+            return (float(low_bucket), float(mid_bucket), float(high_bucket))
         else:
             return (0, 0, 0)

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -4,32 +4,34 @@ import subprocess
 from loguru import logger
 from scipy.signal import butter, sosfilt, sosfreqz
 
-SAMPLERATE=44100
+SAMPLERATE = 44100
+
 
 class SpectralAudioParser:
     """
     reads a given input file, scans along it and parses the amplitude in selected bands using butterworth bandpass filters.
     the amplitude is normalized into the 0..1 range for easier use in transformation functions.
     """
+
     def __init__(
-        self,
-        input_audio,
-        offset,
-        frames_per_second,
-        filters
-        ):
+            self,
+            input_audio,
+            offset,
+            frames_per_second,
+            filters
+    ):
         if len(filters) < 1:
             raise RuntimeError("When using input_audio, at least 1 filter must be specified")
 
         pipe = subprocess.Popen(['ffmpeg', '-i', input_audio,
-            '-f', 's16le',
-            '-acodec', 'pcm_s16le',
-            '-ar', str(SAMPLERATE),
-            '-ac', '1',
-            '-'], stdout=subprocess.PIPE, bufsize=10**8)
+                                 '-f', 's16le',
+                                 '-acodec', 'pcm_s16le',
+                                 '-ar', str(SAMPLERATE),
+                                 '-ac', '1',
+                                 '-'], stdout=subprocess.PIPE, bufsize=10 ** 8)
 
         self.audio_samples = np.array([], dtype=np.int16)
-        
+
         # read the audio file from the pipe in 0.5s blocks (2 bytes per sample)
         while True:
             buf = pipe.stdout.read(SAMPLERATE)
@@ -39,24 +41,25 @@ class SpectralAudioParser:
         if len(self.audio_samples) < 0:
             raise RuntimeError("Audio samples are empty, assuming load failed")
         self.duration = len(self.audio_samples) / SAMPLERATE
-        logger.debug(f"initialized audio file {input_audio}, samples read: {len(self.audio_samples)}, total duration: {self.duration}s")
+        logger.debug(
+            f"initialized audio file {input_audio}, samples read: {len(self.audio_samples)}, total duration: {self.duration}s")
         self.offset = offset
         if offset > self.duration:
             raise RuntimeError(f"Audio offset set at {offset}s but input audio is only {duration}s long")
         # analyze all samples for the current frame
-        self.window_size = int(1/frames_per_second * SAMPLERATE)
+        self.window_size = int(1 / frames_per_second * SAMPLERATE)
         self.filters = filters
 
         # parse band maxima first for normalizing the filtered signal to 0..1 at arbitrary points in the file later
         # this initialization is a bit compute intensive, especially for higher fps numbers, but i couldn't find a cleaner way
         # (band-passing the entire track instead of windows creates maxima that are way off, some filtering anomaly i don't understand...)
         steps = int((self.duration - self.offset) * frames_per_second)
-        interval = 1/frames_per_second
+        interval = 1 / frames_per_second
         maxima = {}
         time_steps = np.linspace(0, steps, num=steps) * interval
         for t in time_steps:
             sample_offset = int(t * SAMPLERATE)
-            cur_maxima = bp_filtered(self.audio_samples[sample_offset:sample_offset+self.window_size], filters)
+            cur_maxima = bp_filtered(self.audio_samples[sample_offset:sample_offset + self.window_size], filters)
             for key in cur_maxima:
                 if key in maxima:
                     maxima[key] = max(maxima[key], cur_maxima[key])
@@ -72,16 +75,14 @@ class SpectralAudioParser:
         """
         # Get the point in time (sample-offset) in the track in seconds based on sample-rate
         sample_offset = int(t * SAMPLERATE + self.offset * SAMPLERATE)
-        logger.debug(f"Analyzing audio at {self.offset+t}s")
+        logger.debug(f"Analyzing audio at {self.offset + t}s")
         if sample_offset < len(self.audio_samples):
-            window_samples = self.audio_samples[sample_offset:sample_offset+self.window_size]
+            window_samples = self.audio_samples[sample_offset:sample_offset + self.window_size]
             if len(window_samples) < self.window_size:
                 # audio input file has likely ended
-                # TODO could round down to the next lower pow2 then do it anyway. not a critical case though IMO.
-                logger.debug(f"Warning: sample offset is out of range at time offset {t+self.offset}s. Returning null result")
+                logger.debug(
+                    f"Warning: sample offset is out of range at time offset {t + self.offset}s. Returning null result")
                 return {}
-            # fade-in / fade-out window to taper off the signal
-            #window_samples = window_samples * np.hamming(len(window_samples))
             return bp_filtered_norm(window_samples, self.filters, self.band_maxima)
         else:
             logger.debug(f"Warning: Audio input has ended. Returning null result")
@@ -90,28 +91,31 @@ class SpectralAudioParser:
     def get_duration(self):
         return self.duration
 
+
 def butter_bandpass(lowcut, highcut, fs, order=5):
-        nyq = 0.5 * fs
-        low = lowcut / nyq
-        high = highcut / nyq
-        sos = butter(order, [low, high], analog=False, btype='bandpass', output='sos')
-        return sos
+    nyq = 0.5 * fs
+    low = lowcut / nyq
+    high = highcut / nyq
+    sos = butter(order, [low, high], analog=False, btype='bandpass', output='sos')
+    return sos
+
 
 def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
-        sos = butter_bandpass(lowcut, highcut, fs, order=order)
-        y = sosfilt(sos, data)
-        return y
+    sos = butter_bandpass(lowcut, highcut, fs, order=order)
+    y = sosfilt(sos, data)
+    return y
 
 
 def bp_filtered(window_samples, filters) -> typing.Dict[str, float]:
     results = {}
     for filter in filters:
-        offset = filter.f_width/2
+        offset = filter.f_width / 2
         lower = filter.f_center - offset
         upper = filter.f_center + offset
         filtered = butter_bandpass_filter(window_samples, lower, upper, SAMPLERATE, order=filter.order)
         results[filter.variable_name] = np.max(np.abs(filtered))
     return results
+
 
 def bp_filtered_norm(window_samples, filters, norm_factors) -> typing.Dict[str, float]:
     results = bp_filtered(window_samples, filters)

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -54,6 +54,7 @@ class SpectralAudioParser:
             if len(window_samples) < self.window_size:
                 # audio input file has likely ended
                 # TODO could round down to the next pow2 then do it anyway. not a critical case though IMO.
+                logger.debug(f"Warning: sample offset is out of range at time offset {t+self.input_audio_offset}s. Returning 0 vector")
                 return (0, 0, 0)
             # fade-in / fade-out window
             window_samples = window_samples * np.hamming(len(window_samples))

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -32,7 +32,7 @@ class SpectralAudioParser:
                     break
             if len(self.audio_samples) < 0:
                 raise RuntimeError("Audio samples are empty, assuming load failed")
-            logger.debug(f"initialized audio file {params.input_audio}")
+            logger.debug(f"initialized audio file {params.input_audio}, samples read: {len(self.audio_samples)}")
             self.input_audio_offset = params.input_audio_offset
             self.window_size = params.input_audio_window_size
             self.low_cutoff = params.input_audio_band_split_low_medium

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -2,6 +2,7 @@ import numpy as np
 import typing
 import subprocess
 from loguru import logger
+from scipy.signal import butter, sosfilt, sosfreqz
 
 SAMPLERATE=44100
 
@@ -12,34 +13,35 @@ class SpectralAudioParser:
     """
     def __init__(
         self,
-        params=None
+        input_audio,
+        offset,
+        window_size,
+        filters
         ):
-        if params.input_audio:
-            pipe = subprocess.Popen(['ffmpeg', '-i', params.input_audio,
-                '-f', 's16le',
-                '-acodec', 'pcm_s16le',
-                '-ar', str(SAMPLERATE),
-                '-ac', '1',
-                '-'], stdout=subprocess.PIPE, bufsize=10**8)
+        pipe = subprocess.Popen(['ffmpeg', '-i', input_audio,
+            '-f', 's16le',
+            '-acodec', 'pcm_s16le',
+            '-ar', str(SAMPLERATE),
+            '-ac', '1',
+            '-'], stdout=subprocess.PIPE, bufsize=10**8)
 
-            self.audio_samples = np.array([], dtype=np.int16)
-            
-            # read the audio file from the pipe in 0.5s blocks (2 bytes per sample)
-            while True:
-                buf = pipe.stdout.read(SAMPLERATE)
-                self.audio_samples = np.append(self.audio_samples, np.frombuffer(buf, dtype=np.int16))
-                if len(buf) < SAMPLERATE:
-                    break
-            if len(self.audio_samples) < 0:
-                raise RuntimeError("Audio samples are empty, assuming load failed")
-            logger.debug(f"initialized audio file {params.input_audio}, samples read: {len(self.audio_samples)}")
-            self.input_audio_offset = params.input_audio_offset
-            self.window_size = params.input_audio_window_size
-            self.low_cutoff = params.input_audio_band_split_low_medium
-            self.mid_cutoff = params.input_audio_band_split_medium_high
-            # pink noise normalization blatantly stolen from https://github.com/aiXander/Realtime_PyAudio_FFT/blob/275c8b1fc268ac946470b0d7a80de56eb2212b58/src/stream_analyzer.py#L107
-            self.fftx = np.arange(int(self.window_size/2), dtype=float) * SAMPLERATE / self.window_size
-            self.power_normalization_coefficients = np.logspace(np.log2(1), np.log2(np.log2(SAMPLERATE/2)), len(self.fftx), endpoint=True, base=2, dtype=None)
+        self.audio_samples = np.array([], dtype=np.int16)
+        
+        # read the audio file from the pipe in 0.5s blocks (2 bytes per sample)
+        while True:
+            buf = pipe.stdout.read(SAMPLERATE)
+            self.audio_samples = np.append(self.audio_samples, np.frombuffer(buf, dtype=np.int16))
+            if len(buf) < SAMPLERATE:
+                break
+        if len(self.audio_samples) < 0:
+            raise RuntimeError("Audio samples are empty, assuming load failed")
+        logger.debug(f"initialized audio file {input_audio}, samples read: {len(self.audio_samples)}")
+        self.offset = offset
+        self.window_size = window_size
+        self.filters = filters
+        # pink noise normalization blatantly stolen from https://github.com/aiXander/Realtime_PyAudio_FFT/blob/275c8b1fc268ac946470b0d7a80de56eb2212b58/src/stream_analyzer.py#L107
+        self.fftx = np.arange(int(self.window_size/2), dtype=float) * SAMPLERATE / self.window_size
+        self.power_normalization_coefficients = np.logspace(np.log2(1), np.log2(np.log2(SAMPLERATE/2)), len(self.fftx), endpoint=True, base=2, dtype=None)
 
 
 
@@ -49,64 +51,90 @@ class SpectralAudioParser:
         Amplitude/energy parameters are normalized into the [0,1] range.
         """
         # Get the point in time (sample-offset) in the track in seconds based on sample-rate
-        sample_offset = int(t * SAMPLERATE + self.input_audio_offset * SAMPLERATE)
-        logger.debug(f"Analyzing audio at {self.input_audio_offset+t}s")
+        sample_offset = int(t * SAMPLERATE + self.offset * SAMPLERATE)
+        logger.debug(f"Analyzing audio at {self.offset+t}s")
         if sample_offset < len(self.audio_samples):
             window_samples = self.audio_samples[sample_offset:sample_offset+self.window_size]
             if len(window_samples) < self.window_size:
                 # audio input file has likely ended
-                # TODO could round down to the next pow2 then do it anyway. not a critical case though IMO.
-                logger.debug(f"Warning: sample offset is out of range at time offset {t+self.input_audio_offset}s. Returning 0 vector")
+                # TODO could round down to the next lower pow2 then do it anyway. not a critical case though IMO.
+                logger.debug(f"Warning: sample offset is out of range at time offset {t+self.offset}s. Returning 0 vector")
                 return (0, 0, 0)
-            # fade-in / fade-out window
+                    
+            # fade-in / fade-out window to taper off the signal
             window_samples = window_samples * np.hamming(len(window_samples))
-            fft = np.fft.fft(window_samples)
-            # summing together the real and imaginary components, i think(??)
-            left, right = np.split(np.abs(fft), 2)
-            fft = np.add(left, right[::-1])
-
-            # pink noise adjust
-            fft = fft * self.power_normalization_coefficients
-
-            freq_buckets = np.fft.fftfreq(self.window_size, 1 / SAMPLERATE)
-            # collect energy for each frequency band
-            # TODO: this could probably be done in a much nicer way with bandpass filters somehow... not sure on the correct arithmetic though
-            low_bucket = 0
-            low_count = 0
-            mid_bucket = 0
-            mid_count = 0
-            high_bucket = 0
-            high_count = 0
-            for i in range(len(fft)):
-                freq = self.fftx[i]
-                if freq < self.low_cutoff:
-                    low_bucket += fft[i]
-                    low_count += 1
-                elif freq < self.mid_cutoff:
-                    mid_bucket += fft[i]
-                    mid_count += 1
-                else:
-                    high_bucket += fft[i]
-                    high_count += 1
-            # mean energy per bucket
-            if low_count > 0 and mid_count > 0 and high_count > 0:    
-                low_bucket = low_bucket / low_count
-                mid_bucket = mid_bucket / mid_count
-                high_bucket = high_bucket / high_count
-            else:
-                logger.debug(f"Warning: There were empty buckets in the audio frequency analysis. Returning 0 vector")
-                return (0,0,0)
-            # normalize to [0,1] range
-            max_val = np.max(fft)
-            if max_val > 0:
-                low_bucket = low_bucket / max_val
-                mid_bucket = mid_bucket / max_val
-                high_bucket = high_bucket / max_val
-            else:
-                logger.debug(f"Warning: Max val was 0 in the audio frequency analysis. Returning 0 vector")
-                return (0,0,0)
-            return (float(low_bucket), float(mid_bucket), float(high_bucket))
+            return bp_tuple(t, window_samples, self.filters)
+            #return fft_tuple(t)
         else:
-
             logger.debug(f"Warning: Audio input has ended. Returning 0 vector")
             return (0, 0, 0)
+
+def butter_bandpass(lowcut, highcut, fs, order=5):
+        nyq = 0.5 * fs
+        low = lowcut / nyq
+        high = highcut / nyq
+        sos = butter(order, [low, high], analog=False, btype='band', output='sos')
+        return sos
+
+def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
+        sos = butter_bandpass(lowcut, highcut, fs, order=order)
+        y = sosfilt(sos, data)
+        return y
+
+def bp_tuple(t, window_samples, filters) -> typing.Dict[str, float]:
+    for filter in filters:
+        offset = filter.f_width/2
+        lower = filter.f_center - offset
+        upper = filter.f_center + offset
+        filtered = butter_bandpass_filter(window_samples, lower, upper, SAMPLERATE, order=filter.order)
+        # Normalize from signed 16-bit max value to 0..1 range
+        val = np.max(np.abs(filtered)) / 32768
+        return (val, 0, 0)
+
+def fft_tuple(t, window_samples) -> typing.Tuple[float, float, float]:
+    fft = np.fft.fft(window_samples)
+    # summing together the real and imaginary components, i think(??)
+    left, right = np.split(np.abs(fft), 2)
+    fft = np.add(left, right[::-1])
+
+    # pink noise adjust
+    fft = fft * self.power_normalization_coefficients
+
+    freq_buckets = np.fft.fftfreq(self.window_size, 1 / SAMPLERATE)
+    # collect energy for each frequency band
+    # TODO: this could probably be done in a much nicer way with bandpass filters somehow... not sure on the correct arithmetic though
+    low_bucket = 0
+    low_count = 0
+    mid_bucket = 0
+    mid_count = 0
+    high_bucket = 0
+    high_count = 0
+    for i in range(len(fft)):
+        freq = self.fftx[i]
+        if freq < self.low_cutoff:
+            low_bucket += fft[i]
+            low_count += 1
+        elif freq < self.mid_cutoff:
+            mid_bucket += fft[i]
+            mid_count += 1
+        else:
+            high_bucket += fft[i]
+            high_count += 1
+    # mean energy per bucket
+    if low_count > 0 and mid_count > 0 and high_count > 0:    
+        low_bucket = low_bucket / low_count
+        mid_bucket = mid_bucket / mid_count
+        high_bucket = high_bucket / high_count
+    else:
+        logger.debug(f"Warning: There were empty buckets in the audio frequency analysis. Returning 0 vector")
+        return (0,0,0)
+    # normalize to [0,1] range
+    max_val = np.max(fft)
+    if max_val > 0:
+        low_bucket = low_bucket / max_val
+        mid_bucket = mid_bucket / max_val
+        high_bucket = high_bucket / max_val
+    else:
+        logger.debug(f"Warning: Max val was 0 in the audio frequency analysis. Returning 0 vector")
+        return (0,0,0)
+    return (float(low_bucket), float(mid_bucket), float(high_bucket))

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -30,7 +30,8 @@ class SpectralAudioParser:
                 self.audio_samples = np.append(self.audio_samples, np.frombuffer(buf, dtype=np.int16))
                 if len(buf) < SAMPLERATE:
                     break
-            
+            if len(self.audio_samples) < 0:
+                raise RuntimeError("Audio samples are empty, assuming load failed")
             logger.debug(f"initialized audio file {params.input_audio}")
             self.input_audio_offset = params.input_audio_offset
             self.window_size = params.input_audio_window_size

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -1,6 +1,9 @@
 import numpy as np
-import audiofile
 import typing
+import subprocess
+from loguru import logger
+
+SAMPLERATE=44100
 
 class SpectralAudioParser:
     """
@@ -12,18 +15,85 @@ class SpectralAudioParser:
         params=None
         ):
         if params.input_audio:
-            self.audio_samples, self.sample_rate = audiofile.read(params.input_audio, offset=params.input_audio_offset, always_2d=True)
+            pipe = subprocess.Popen(['ffmpeg', '-i', params.input_audio,
+                '-f', 's16le',
+                '-acodec', 'pcm_s16le',
+                '-ar', str(SAMPLERATE),
+                '-ac', '1',
+                '-'], stdout=subprocess.PIPE, bufsize=10**8)
+
+            self.audio_samples = np.array([], dtype=np.int16)
+            
+            # read the audio file from the pipe in 0.5s blocks (2 bytes per sample)
+            while True:
+                buf = pipe.stdout.read(SAMPLERATE)
+                self.audio_samples = np.append(self.audio_samples, np.frombuffer(buf, dtype=np.int16))
+                if len(buf) < SAMPLERATE:
+                    break
+            
+            logger.debug(f"initialized audio file {params.input_audio}")
+            self.input_audio_offset = params.input_audio_offset
+            self.window_size = params.input_audio_window_size
+            self.low_cutoff = params.input_audio_band_split_low_medium
+            self.mid_cutoff = params.input_audio_band_split_medium_high
+            # pink noise normalization blatantly stolen from https://github.com/aiXander/Realtime_PyAudio_FFT/blob/275c8b1fc268ac946470b0d7a80de56eb2212b58/src/stream_analyzer.py#L107
+            self.fftx = np.arange(int(self.window_size/2), dtype=float) * SAMPLERATE / self.window_size
+            self.power_normalization_coefficients = np.logspace(np.log2(1), np.log2(np.log2(SAMPLERATE/2)), len(self.fftx), endpoint=True, base=2, dtype=None)
+
+
 
     def get_params(self, t) -> typing.Tuple[float, float, float]:
         """
         Return the amplitude parameters at the given point in time t within the audio track, or 0 if the track has ended.
+        Amplitude/energy parameters are normalized into the [0,1] range.
         """
         # Get the point in time (sample-offset) in the track in seconds based on sample-rate
-        sample_offset = int(t * self.sample_rate)
-        if sample_offset < self.audio_samples.shape[0]:
-            # TODO: read back up on numpy array slicing, read [sample_offset, sample_offset+window_size] here
-            #       read back up on fft window size parameters etc.
-            #       read up on whether to use fft2 here or to sum the audio file on initialization into a mono signal first maybe
-            np.fft.fft2(self.audio_samples[:sample_offset])
+        sample_offset = int(t * SAMPLERATE + self.input_audio_offset * SAMPLERATE)
+        if sample_offset < len(self.audio_samples):
+            window_samples = self.audio_samples[sample_offset:sample_offset+self.window_size]
+            if len(window_samples) < self.window_size:
+                # audio input file has likely ended
+                # TODO could round down to the next pow2 then do it anyway. not a critical case though IMO.
+                return (0, 0, 0)
+            # fade-in / fade-out window
+            window_samples = window_samples * np.hamming(len(window_samples))
+            fft = np.fft.fft(window_samples)
+            # summing together the real and imaginary components, i think(??)
+            left, right = np.split(np.abs(fft), 2)
+            fft = np.add(left, right[::-1])
+
+            # pink noise adjust
+            fft = fft * self.power_normalization_coefficients
+
+            freq_buckets = np.fft.fftfreq(self.window_size, 1 / SAMPLERATE)
+            # collect energy for each frequency band
+            # TODO: this could probably be done in a much nicer way with bandpass filters somehow... not sure on the correct arithmetic though
+            low_bucket = 0
+            low_count = 0
+            mid_bucket = 0
+            mid_count = 0
+            high_bucket = 0
+            high_count = 0
+            for i in range(len(fft)):
+                freq = self.fftx[i]
+                if freq < self.low_cutoff:
+                    low_bucket += fft[i]
+                    low_count += 1
+                elif freq < self.mid_cutoff:
+                    mid_bucket += fft[i]
+                    mid_count += 1
+                else:
+                    high_bucket += fft[i]
+                    high_count += 1
+            # mean energy per bucket
+            low_bucket = low_bucket / low_count
+            mid_bucket = mid_bucket / mid_count
+            high_bucket = high_bucket / high_count
+            # normalize to [0,1] range
+            max_val = np.max(fft)
+            low_bucket = low_bucket / max_val
+            mid_bucket = mid_bucket / max_val
+            high_bucket = high_bucket / max_val
+            return (low_bucket, mid_bucket, high_bucket)
         else:
             return (0, 0, 0)

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -1,0 +1,29 @@
+import numpy as np
+import audiofile
+import typing
+
+class SpectralAudioParser:
+    """
+    Audio Parser reads a given input file, scans along it and parses its spectrum using FFT.
+    The FFT output is split into three bands (low,mid,high), the (average) amplitude of which is then returned for use in animation functions.
+    """
+    def __init__(
+        self,
+        params=None
+        ):
+        if params.input_audio:
+            self.audio_samples, self.sample_rate = audiofile.read(params.input_audio, offset=params.input_audio_offset, always_2d=True)
+
+    def get_params(self, t) -> typing.Tuple[float, float, float]:
+        """
+        Return the amplitude parameters at the given point in time t within the audio track, or 0 if the track has ended.
+        """
+        # Get the point in time (sample-offset) in the track in seconds based on sample-rate
+        sample_offset = int(t * self.sample_rate)
+        if sample_offset < self.audio_samples.shape[0]:
+            # TODO: read back up on numpy array slicing, read [sample_offset, sample_offset+window_size] here
+            #       read back up on fft window size parameters etc.
+            #       read up on whether to use fft2 here or to sum the audio file on initialization into a mono signal first maybe
+            np.fft.fft2(self.audio_samples[:sample_offset])
+        else:
+            return (0, 0, 0)

--- a/src/pytti/AudioParse.py
+++ b/src/pytti/AudioParse.py
@@ -50,6 +50,7 @@ class SpectralAudioParser:
         """
         # Get the point in time (sample-offset) in the track in seconds based on sample-rate
         sample_offset = int(t * SAMPLERATE + self.input_audio_offset * SAMPLERATE)
+        logger.debug(f"Analyzing audio at {self.input_audio_offset+t}s")
         if sample_offset < len(self.audio_samples):
             window_samples = self.audio_samples[sample_offset:sample_offset+self.window_size]
             if len(window_samples) < self.window_size:
@@ -93,6 +94,7 @@ class SpectralAudioParser:
                 mid_bucket = mid_bucket / mid_count
                 high_bucket = high_bucket / high_count
             else:
+                logger.debug(f"Warning: There were empty buckets in the audio frequency analysis. Returning 0 vector")
                 return (0,0,0)
             # normalize to [0,1] range
             max_val = np.max(fft)
@@ -101,7 +103,10 @@ class SpectralAudioParser:
                 mid_bucket = mid_bucket / max_val
                 high_bucket = high_bucket / max_val
             else:
+                logger.debug(f"Warning: Max val was 0 in the audio frequency analysis. Returning 0 vector")
                 return (0,0,0)
             return (float(low_bucket), float(mid_bucket), float(high_bucket))
         else:
+
+            logger.debug(f"Warning: Audio input has ended. Returning 0 vector")
             return (0, 0, 0)

--- a/src/pytti/ImageGuide.py
+++ b/src/pytti/ImageGuide.py
@@ -110,7 +110,7 @@ class DirectImageGuide:
         self.dataframe = []
 
         if params.input_audio:
-            self.audio_parser = SpectralAudioParser(params)
+            self.audio_parser = SpectralAudioParser(params.input_audio, params.offset, params.window_size, params.filters)
         else:
             self.audio_parser = None
 

--- a/src/pytti/ImageGuide.py
+++ b/src/pytti/ImageGuide.py
@@ -109,8 +109,9 @@ class DirectImageGuide:
             self.optimizer = optimizer
         self.dataframe = []
 
-        if params.input_audio:
-            self.audio_parser = SpectralAudioParser(params.input_audio, params.offset, params.frames_per_second, params.filters)
+        if params.input_audio and params.input_audio_filters:
+            self.audio_parser = SpectralAudioParser(params.input_audio, params.input_audio_offset,
+                                                    params.frames_per_second, params.input_audio_filters)
         else:
             self.audio_parser = None
 
@@ -529,7 +530,7 @@ class DirectImageGuide:
             if (i - params.pre_animation_steps) % params.steps_per_frame == 0:
                 if self.audio_parser is not None:
                     band_dict = self.audio_parser.get_params(t)
-                    logger.debug(f"Time: {t:.4f} seconds, audio params: lo: {lo:.4f}, mid: {mid:.4f}, hi: {hi:.4f}")
+                    logger.debug(f"Time: {t:.4f} seconds, audio params: {band_dict}")
                     set_t(t, band_dict)
                 else:
                     logger.debug(f"Time: {t:.4f} seconds")

--- a/src/pytti/ImageGuide.py
+++ b/src/pytti/ImageGuide.py
@@ -525,13 +525,14 @@ class DirectImageGuide:
             set_t(t, 0, 0, 0)
         # set_t(t)  # this won't need to be a thing with `t`` attached to the class
         if i >= params.pre_animation_steps:
-            if self.audio_parser is not None:
-                lo, mid, hi = self.audio_parser.get_params(t)
-                logger.debug(f"Time: {t:.4f} seconds, audio params: lo: {lo:.4f}, mid: {mid:.4f}, hi: {hi:.4f}")
-                set_t(t, lo, mid, hi)
             # next_step_pil = None
             if (i - params.pre_animation_steps) % params.steps_per_frame == 0:
-                logger.debug(f"Time: {t:.4f} seconds")
+                if self.audio_parser is not None:
+                    lo, mid, hi = self.audio_parser.get_params(t)
+                    logger.debug(f"Time: {t:.4f} seconds, audio params: lo: {lo:.4f}, mid: {mid:.4f}, hi: {hi:.4f}")
+                    set_t(t, lo, mid, hi)
+                else:
+                    logger.debug(f"Time: {t:.4f} seconds")
                 # update_rotoscopers(
                 ROTOSCOPERS.update_rotoscopers(
                     ((i - params.pre_animation_steps) // params.steps_per_frame + 1)

--- a/src/pytti/ImageGuide.py
+++ b/src/pytti/ImageGuide.py
@@ -110,7 +110,7 @@ class DirectImageGuide:
         self.dataframe = []
 
         if params.input_audio:
-            self.audio_parser = SpectralAudioParser(params.input_audio, params.offset, params.window_size, params.filters)
+            self.audio_parser = SpectralAudioParser(params.input_audio, params.offset, params.frames_per_second, params.filters)
         else:
             self.audio_parser = None
 
@@ -528,9 +528,9 @@ class DirectImageGuide:
             # next_step_pil = None
             if (i - params.pre_animation_steps) % params.steps_per_frame == 0:
                 if self.audio_parser is not None:
-                    lo, mid, hi = self.audio_parser.get_params(t)
+                    band_dict = self.audio_parser.get_params(t)
                     logger.debug(f"Time: {t:.4f} seconds, audio params: lo: {lo:.4f}, mid: {mid:.4f}, hi: {hi:.4f}")
-                    set_t(t, lo, mid, hi)
+                    set_t(t, band_dict)
                 else:
                     logger.debug(f"Time: {t:.4f} seconds")
                 # update_rotoscopers(

--- a/src/pytti/ImageGuide.py
+++ b/src/pytti/ImageGuide.py
@@ -523,7 +523,7 @@ class DirectImageGuide:
             params.steps_per_frame * params.frames_per_second
         )
         if self.audio_parser is None:
-            set_t(t, 0, 0, 0)
+            set_t(t, {})
         # set_t(t)  # this won't need to be a thing with `t`` attached to the class
         if i >= params.pre_animation_steps:
             # next_step_pil = None

--- a/src/pytti/assets/default.yaml
+++ b/src/pytti/assets/default.yaml
@@ -81,6 +81,11 @@ far_plane: 10000
 ######################
 ### Induced Motion ###
 ######################
+input_audio: ""
+input_audio_offset: 0
+input_audio_window_size: 8192
+input_audio_band_split_low_medium: 150
+input_audio_band_split_medium_high: 300
 
 pre_animation_steps: 100
 lock_camera: true

--- a/src/pytti/assets/default.yaml
+++ b/src/pytti/assets/default.yaml
@@ -84,8 +84,11 @@ far_plane: 10000
 input_audio: ""
 input_audio_offset: 0
 input_audio_window_size: 8192
-input_audio_band_split_low_medium: 150
-input_audio_band_split_medium_high: 300
+input_audio_filters: []
+# - variable_name: fLo
+#   f_center: 60
+#   f_width: 30
+#   order: 5
 
 pre_animation_steps: 100
 lock_camera: true

--- a/src/pytti/assets/default.yaml
+++ b/src/pytti/assets/default.yaml
@@ -83,7 +83,6 @@ far_plane: 10000
 ######################
 input_audio: ""
 input_audio_offset: 0
-input_audio_window_size: 8192
 input_audio_filters: []
 # - variable_name: fLo
 #   f_center: 60

--- a/src/pytti/config/structured_config.py
+++ b/src/pytti/config/structured_config.py
@@ -109,7 +109,6 @@ class ConfigSchema:
 
     input_audio: str = ""
     input_audio_offset: float = 0
-    input_audio_window_size: int = 1024
     input_audio_filters: AudioFilterConfig = None
 
     #  _2d and _3d only apply to those animation modes

--- a/src/pytti/config/structured_config.py
+++ b/src/pytti/config/structured_config.py
@@ -100,6 +100,12 @@ class ConfigSchema:
     ### Induced Motion ###
     ######################
 
+    input_audio: str = ""
+    input_audio_offset: float = 0
+    input_audio_window_size: int = 1024
+    input_audio_band_split_low_medium: int = 500
+    input_audio_band_split_medium_high: int = 3500
+
     #  _2d and _3d only apply to those animation modes
 
     translate_x: str = "0"

--- a/src/pytti/config/structured_config.py
+++ b/src/pytti/config/structured_config.py
@@ -17,6 +17,13 @@ def check_input_against_list(attribute, value, valid_values):
 
 
 @define(auto_attribs=True)
+class AudioFilterConfig:
+    variable_name: str = "???"
+    f_center: int = "???"
+    f_width: int = "???"
+    order: int = 5
+
+@define(auto_attribs=True)
 class ConfigSchema:
     #############
     ## Prompts ##
@@ -103,8 +110,7 @@ class ConfigSchema:
     input_audio: str = ""
     input_audio_offset: float = 0
     input_audio_window_size: int = 1024
-    input_audio_band_split_low_medium: int = 500
-    input_audio_band_split_medium_high: int = 3500
+    input_audio_filters: AudioFilterConfig = None
 
     #  _2d and _3d only apply to those animation modes
 

--- a/src/pytti/eval_tools.py
+++ b/src/pytti/eval_tools.py
@@ -5,9 +5,7 @@ import io
 
 math_env = None
 global_t = 0
-global_fLo = 0
-global_fMid = 0
-global_fHi = 0
+global_bands = {}
 eval_memo = {}
 
 
@@ -30,9 +28,9 @@ def parametric_eval(string, **vals):
             )
         math_env.update(vals)
         math_env["t"] = global_t
-        math_env["fLo"] = global_fLo
-        math_env["fMid"] = global_fMid
-        math_env["fHi"] = global_fHi
+        # TODO set envs from global bandpass dict values 
+        for band in global_bands:
+            math_env[band] = global_bands[band]
         try:
             output = eval(string, math_env)
         except SyntaxError as e:
@@ -43,12 +41,10 @@ def parametric_eval(string, **vals):
         return string
 
 
-def set_t(t, fLo, fMid, fHi):
-    global global_t, global_fLo, global_fMid, global_fHi, eval_memo
+def set_t(t, band_dict):
+    global global_t, global_bands, eval_memo
     global_t = t
-    global_fLo = fLo
-    global_fMid = fMid
-    global_fHi = fHi
+    global_bands = band_dict
     eval_memo = {}
 
 

--- a/src/pytti/eval_tools.py
+++ b/src/pytti/eval_tools.py
@@ -5,6 +5,9 @@ import io
 
 math_env = None
 global_t = 0
+global_fLo = 0
+global_fMid = 0
+global_fHi = 0
 eval_memo = {}
 
 
@@ -27,6 +30,9 @@ def parametric_eval(string, **vals):
             )
         math_env.update(vals)
         math_env["t"] = global_t
+        math_env["fLo"] = global_fLo
+        math_env["fMid"] = global_fMid
+        math_env["fHi"] = global_fHi
         try:
             output = eval(string, math_env)
         except SyntaxError as e:
@@ -37,9 +43,12 @@ def parametric_eval(string, **vals):
         return string
 
 
-def set_t(t):
-    global global_t, eval_memo
+def set_t(t, fLo, fMid, fHi):
+    global global_t, global_fLo, global_fMid, global_fHi, eval_memo
     global_t = t
+    global_fLo = fLo
+    global_fMid = fMid
+    global_fHi = fHi
     eval_memo = {}
 
 

--- a/src/pytti/eval_tools.py
+++ b/src/pytti/eval_tools.py
@@ -6,6 +6,7 @@ import io
 math_env = None
 global_t = 0
 global_bands = {}
+global_bands_prev = {}
 eval_memo = {}
 
 
@@ -28,9 +29,11 @@ def parametric_eval(string, **vals):
             )
         math_env.update(vals)
         math_env["t"] = global_t
-        # TODO set envs from global bandpass dict values 
         for band in global_bands:
             math_env[band] = global_bands[band]
+        if global_bands_prev:
+            for band in global_bands_prev:
+                math_env[f'{band}_prev'] = global_bands_prev[band]
         try:
             output = eval(string, math_env)
         except SyntaxError as e:
@@ -42,8 +45,12 @@ def parametric_eval(string, **vals):
 
 
 def set_t(t, band_dict):
-    global global_t, global_bands, eval_memo
+    global global_t, global_bands, global_bands_prev, eval_memo
     global_t = t
+    if global_bands:
+        global_bands_prev = global_bands
+    else:
+        global_bands_prev = band_dict
     global_bands = band_dict
     eval_memo = {}
 


### PR DESCRIPTION
closes #102 

i started the issue with my thought of making it FFT based, where i sorted frequencies into buckets.
this is a more versatile approach now:
instead of dealing with FFT window sizes and all that sort of stuff, we just take the corresponding audio signal for the time the current frame will last and pass the signal through configurable butterworth band pass filters.

one additional trick: when loading the audio initially, we run the bandpass filters across the whole track and find the maxima to normalize the signal to the `0..1` range for the individual bands so the signal will always end up covering the full 0..1 range in the input, for easier use in functions.

feel free to request whatever else you need, i wouldn't mind writing some docs with some basic examples / hints or adding stuff to the notebook where needed.