### PR TITLE
mmc support

### DIFF
--- a/src/pytti/Notebook.py
+++ b/src/pytti/Notebook.py
@@ -18,6 +18,8 @@ import clip
 
 from pytti import Perceptor
 
+from pytti.Perceptor import CLIP_PERCEPTORS
+
 
 # https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
 def is_notebook():
@@ -264,9 +266,9 @@ def load_clip(params):
         import mmc.loaders  # force trigger model registrations
         from mmc.mock.openai import MockOpenaiClip
 
-        # ugh....
-        global CLIP_PERCEPTORS
-        CLIP_PERCEPTORS = []
+        CLIP_PERCEPTORS = (
+            []
+        )  # this will be fine because we'll use it to overwrite the module object
         for item in params.mmc_models:
             logger.debug(item)
             model_loaders = REGISTRY.find(**item)
@@ -276,3 +278,5 @@ def load_clip(params):
                 model = model_loader.load()
                 model = MockOpenaiClip(model)
                 CLIP_PERCEPTORS.append(model)
+        logger.debug(CLIP_PERCEPTORS)
+        Perceptor.CLIP_PERCEPTORS = CLIP_PERCEPTORS  # weird that htis works, but fine.

--- a/tests/test_mmc_loaders.py
+++ b/tests/test_mmc_loaders.py
@@ -1,0 +1,38 @@
+import pytest
+
+from hydra import initialize, compose
+from loguru import logger
+from pytti.workhorse import _main as render_frames
+from omegaconf import OmegaConf, open_dict
+
+
+CONFIG_BASE_PATH = "config"
+CONFIG_DEFAULTS = "default.yaml"
+
+
+cfg_yaml0 = """# @package _global_
+scenes: a photograph of an apple
+use_mmc: true
+mmc_models:
+- architecture: clip
+  publisher: openai
+  id: RN50
+- architecture: clip
+  publisher: openai
+  id: ViT-B/32
+"""
+
+
+def test_mmc_openai_models():
+
+    with initialize(config_path=CONFIG_BASE_PATH):
+        cfg_base = compose(
+            config_name=CONFIG_DEFAULTS,
+            overrides=[f"conf=_empty"],
+        )
+        cfg_mmc = OmegaConf.create(cfg_yaml0)
+
+        with open_dict(cfg_base) as cfg:
+            # cfg.update(cfg_mmc)
+            cfg = OmegaConf.merge(cfg_base, cfg_mmc)
+        render_frames(cfg)

--- a/tests/test_mmc_loaders.py
+++ b/tests/test_mmc_loaders.py
@@ -10,7 +10,7 @@ CONFIG_BASE_PATH = "config"
 CONFIG_DEFAULTS = "default.yaml"
 
 
-cfg_yaml0 = """# @package _global_
+cfg_yaml_openai = """# @package _global_
 scenes: a photograph of an apple
 use_mmc: true
 mmc_models:
@@ -30,9 +30,35 @@ def test_mmc_openai_models():
             config_name=CONFIG_DEFAULTS,
             overrides=[f"conf=_empty"],
         )
-        cfg_mmc = OmegaConf.create(cfg_yaml0)
+        cfg_mmc = OmegaConf.create(cfg_yaml_openai)
 
         with open_dict(cfg_base) as cfg:
-            # cfg.update(cfg_mmc)
+            cfg = OmegaConf.merge(cfg_base, cfg_mmc)
+        render_frames(cfg)
+
+
+cfg_yaml_mlf = """# @package _global_
+scenes: a photograph of an apple
+use_mmc: true
+mmc_models:
+- architecture: clip
+  publisher: mlfoundations
+  id: RN50--yfcc15m
+- architecture: clip
+  publisher: mlfoundations
+  id: ViT-B-32--laion400m_avg
+"""
+
+
+def test_mmc_mlf_models():
+
+    with initialize(config_path=CONFIG_BASE_PATH):
+        cfg_base = compose(
+            config_name=CONFIG_DEFAULTS,
+            overrides=[f"conf=_empty"],
+        )
+        cfg_mmc = OmegaConf.create(cfg_yaml_mlf)
+
+        with open_dict(cfg_base) as cfg:
             cfg = OmegaConf.merge(cfg_base, cfg_mmc)
         render_frames(cfg)

--- a/tests/test_mmc_loaders.py
+++ b/tests/test_mmc_loaders.py
@@ -62,3 +62,26 @@ def test_mmc_mlf_models():
         with open_dict(cfg_base) as cfg:
             cfg = OmegaConf.merge(cfg_base, cfg_mmc)
         render_frames(cfg)
+
+
+cfg_yaml_all_cloob = """# @package _global_
+scenes: a photograph of an apple
+use_mmc: true
+mmc_models:
+- architecture: cloob
+  id: cloob_laion_400m_vit_b_16_32_epochs
+"""
+
+
+def test_mmc_all_cloob_models():
+
+    with initialize(config_path=CONFIG_BASE_PATH):
+        cfg_base = compose(
+            config_name=CONFIG_DEFAULTS,
+            overrides=[f"conf=_empty"],
+        )
+        cfg_mmc = OmegaConf.create(cfg_yaml_all_cloob)
+
+        with open_dict(cfg_base) as cfg:
+            cfg = OmegaConf.merge(cfg_base, cfg_mmc)
+        render_frames(cfg)


### PR DESCRIPTION
successfully tested mmc loading for select openai and mlfoundations models. To activate feature:

1. Install mmc
2. add mmc model spec to config:
```
use_mmc: true
mmc_models:
- architecture: clip
  publisher: mlfoundations
  id: RN50--yfcc15m
- architecture: clip
  publisher: mlfoundations
  id: ViT-B-32--laion400m_avg
```