### PR TITLE
Device selection

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,54 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[[source]]
+url = "https://download.pytorch.org/whl/cu113/"
+verify_ssl = false
+name = "pytorch"
+
+[packages]
+transformers = "==4.15.0"
+gdown = "===4.2.0"
+ftfy = "==6.0.3"
+regex = "*"
+tqdm = "==4.62.3"
+omegaconf = "==2.1.1"
+pytorch-lightning = "==1.5.7"
+kornia = "==0.6.2"
+einops = "==0.3.2"
+imageio-ffmpeg = "==0.4.5"
+exrex = "*"
+matplotlib-label-lines = "==0.4.3"
+pandas = "==1.3.4"
+seaborn = "==0.11.2"
+scikit-learn = "*"
+loguru = "*"
+hydra-core = "*"
+jupyter = "*"
+imageio = "==2.4.1"
+PyGLM = "==2.5.7"
+adjustText = "*"
+Pillow = "*"
+torch = "*"
+torchvision = "*"
+torchaudio = "*"
+requests = "*"
+pyttitools-adabins = {path = "./vendor/AdaBins"}
+pyttitools-gma = {path = "./vendor/GMA"}
+clip = {path = "./vendor/CLIP"}
+pyttitools-taming-transformers = {path = "./vendor/taming-transformers"}
+tensorflow = "*"
+protobuf = "==3.9.2"
+pyttitools-core = {path = "."}
+mmc = {git = "https://github.com/dmarx/Multi-Modal-Comparators"}
+
+[dev-packages]
+pytest = "*"
+pre-commit = "*"
+click = "==8.0.4"
+black = "*"
+
+[requires]
+python_version = "3.9"

--- a/src/pytti/LossAug/BaseLossClass.py
+++ b/src/pytti/LossAug/BaseLossClass.py
@@ -1,10 +1,10 @@
 import torch
 from torch import nn
-from pytti import DEVICE, replace_grad, parametric_eval
+from pytti import replace_grad, parametric_eval
 
 
 class Loss(nn.Module):
-    def __init__(self, weight, stop, name):
+    def __init__(self, weight, stop, name, device=None):
         super().__init__()
         # self.register_buffer('weight', torch.as_tensor(weight))
         # self.register_buffer('stop', torch.as_tensor(stop))
@@ -13,6 +13,9 @@ class Loss(nn.Module):
         self.input_axes = ("n", "s", "y", "x")
         self.name = name
         self.enabled = True
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = device
 
     def get_loss(self, input, img):
         raise NotImplementedError
@@ -29,10 +32,11 @@ class Loss(nn.Module):
     def __str__(self):
         return self.name
 
-    def forward(self, input, img, device=DEVICE):
+    def forward(self, input, img, device=None):
         if not self.enabled or self.weight in [0, "0"]:
             return 0, 0
-
+        if device is None:
+            device = self.device
         weight = torch.as_tensor(parametric_eval(self.weight), device=device)
         stop = torch.as_tensor(parametric_eval(self.stop), device=device)
         loss_raw = self.get_loss(input, img)

--- a/src/pytti/LossAug/LossOrchestratorClass.py
+++ b/src/pytti/LossAug/LossOrchestratorClass.py
@@ -125,6 +125,7 @@ def configure_optical_flows(img, params, loss_augs):
             TargetFlowLoss.TargetImage(
                 f"optical flow stabilization:{params.flow_stabilization_weight}",
                 img.image_shape,
+                device="cuda",
             )
         ]
         for optical_flow in optical_flows:

--- a/src/pytti/LossAug/OpticalFlowLossClass.py
+++ b/src/pytti/LossAug/OpticalFlowLossClass.py
@@ -115,8 +115,9 @@ class TargetFlowLoss(MSELoss):
         stop=-math.inf,
         name="direct target loss",
         image_shape=None,
+        device=None,
     ):
-        super().__init__(comp, weight, stop, name, image_shape)
+        super().__init__(comp, weight, stop, name, image_shape, device)
         with torch.no_grad():
             self.register_buffer("last_step", comp.clone())
             self.mag = 1

--- a/src/pytti/Notebook.py
+++ b/src/pytti/Notebook.py
@@ -233,7 +233,10 @@ logger.debug(SUPPORTED_CLIP_MODELS)
 CLIP_MODEL_NAMES = None
 
 
-def load_clip(params):
+def load_clip(params, device=None):
+
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     # refactor to specify this stuff in a config file
     global CLIP_MODEL_NAMES
@@ -257,7 +260,7 @@ def load_clip(params):
                 raise RuntimeError("Please select at least one CLIP model")
             Perceptor.free_clip()
             logger.debug("Loading CLIP...")
-            Perceptor.init_clip(CLIP_MODEL_NAMES)
+            Perceptor.init_clip(CLIP_MODEL_NAMES, device=device)
             logger.debug("CLIP loaded.")
     else:
         logger.debug("attempting to use mmc to load perceptors")

--- a/src/pytti/Perceptor/Embedder.py
+++ b/src/pytti/Perceptor/Embedder.py
@@ -62,7 +62,6 @@ class HDMultiClipEmbedder(nn.Module):
         self.border_mode = border_mode
 
     def make_cutouts(
-<<<<<<< HEAD
         self,
         input: torch.Tensor,
         side_x,

--- a/src/pytti/Perceptor/Embedder.py
+++ b/src/pytti/Perceptor/Embedder.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
 import pytti
-from pytti import DEVICE, format_input, cat_with_pad, format_module, normalize
+from pytti import format_input, cat_with_pad, format_module, normalize
 
 # from pytti.ImageGuide import DirectImageGuide
 from pytti.image_models import DifferentiableImage
@@ -42,8 +42,12 @@ class HDMultiClipEmbedder(nn.Module):
         padding=0.25,
         border_mode="clamp",
         noise_fac=0.1,
+        device=None,
     ):
         super().__init__()
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = device
         if perceptors is None:
             perceptors = pytti.Perceptor.CLIP_PERCEPTORS
         self.cut_sizes = [p.visual.input_resolution for p in perceptors]
@@ -58,6 +62,7 @@ class HDMultiClipEmbedder(nn.Module):
         self.border_mode = border_mode
 
     def make_cutouts(
+<<<<<<< HEAD
         self,
         input: torch.Tensor,
         side_x,
@@ -71,8 +76,10 @@ class HDMultiClipEmbedder(nn.Module):
         # augs,
         # noise_fac,
         ####
-        device=DEVICE,
+        device=None,
     ) -> Tuple[list, list, list]:
+        if device is None:
+            device = self.device
         cutouts, offsets, sizes = cutouts_samplers.pytti_classic(
             input=input,
             side_x=side_x,
@@ -84,7 +91,7 @@ class HDMultiClipEmbedder(nn.Module):
             border_mode=self.border_mode,
             augs=self.augs,
             noise_fac=self.noise_fac,
-            device=DEVICE,
+            device=device,
         )
         return cutouts, offsets, sizes
 
@@ -93,12 +100,14 @@ class HDMultiClipEmbedder(nn.Module):
         # diff_image: DirectImageGuide,
         diff_image: DifferentiableImage,
         input=None,
-        device=DEVICE,
+        device=None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         diff_image: (DifferentiableImage) input image
         returns images embeds
         """
+        if device is None:
+            device = self.device
         perceptors = self.perceptors
         side_x, side_y = diff_image.image_shape
         if input is None:

--- a/src/pytti/Perceptor/__init__.py
+++ b/src/pytti/Perceptor/__init__.py
@@ -1,19 +1,21 @@
 import torch
 from clip import clip
-from pytti import DEVICE, vram_usage_mode
+from pytti import vram_usage_mode
 
 CLIP_PERCEPTORS = None
 
 # this should probably be a method on the multiperceptor guide
 @vram_usage_mode("CLIP")
-def init_clip(clip_models):
+def init_clip(clip_models, device=None):
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     global CLIP_PERCEPTORS
     if CLIP_PERCEPTORS is None:
         CLIP_PERCEPTORS = [
             clip.load(model, jit=False)[0]
             .eval()
             .requires_grad_(False)
-            .to(DEVICE, memory_format=torch.channels_last)
+            .to(device, memory_format=torch.channels_last)
             for model in clip_models
         ]
 

--- a/src/pytti/Transforms.py
+++ b/src/pytti/Transforms.py
@@ -241,7 +241,7 @@ def zoom_3d(
     f = width / height
 
     # convert depth map
-    depth_map, depth_resized = DepthLoss.get_depth(pil_image)
+    depth_map, depth_resized = DepthLoss.get_depth(pil_image, device=device)
     depth_min = np.min(depth_map)
     depth_max = np.max(depth_map)
     # depth_image = Image.fromarray(np.array(np.interp(depth_map.squeeze(), (depth_min, depth_max), (0,255)), dtype=np.uint8))

--- a/src/pytti/Transforms.py
+++ b/src/pytti/Transforms.py
@@ -161,7 +161,7 @@ def render_image_3d(
 
     if device is None:
         device = image.device
-
+    logger.debug(device)
     y, x = torch.meshgrid(torch.linspace(-1, 1, h), torch.linspace(-f, f, w))
     x = x.unsqueeze(0).unsqueeze(0)
     y = y.unsqueeze(0).unsqueeze(0)
@@ -283,7 +283,7 @@ def zoom_3d(
     # )
 
     ########################################
-
+    logger.debug(device)
     try:
         image_tensor = img.get_image_tensor().to(device)
         depth_tensor = (
@@ -326,7 +326,9 @@ def zoom_3d(
         border_mode=border_mode,
         sampling_mode=sampling_mode,
         stabilize=stabilize,
+        device=device,
     )
+    logger.debug(new_image.device)
     if not fallback:
         img.set_image_tensor(new_image)
     else:

--- a/src/pytti/image_models/rgb_image.py
+++ b/src/pytti/image_models/rgb_image.py
@@ -45,7 +45,7 @@ class RGBImage(DifferentiableImage):
         self.tensor.set_(tensor.unsqueeze(0))
 
     @torch.no_grad()
-    def encode_image(self, pil_image, device, **kwargs):
+    def encode_image(self, pil_image, device=None, **kwargs):
         if device is None:
             device = self.device
         width, height = self.image_shape

--- a/src/pytti/image_models/rgb_image.py
+++ b/src/pytti/image_models/rgb_image.py
@@ -1,4 +1,4 @@
-from pytti import DEVICE, clamp_with_grad
+from pytti import clamp_with_grad
 import torch
 from torch import nn
 from torchvision.transforms import functional as TF
@@ -12,11 +12,14 @@ class RGBImage(DifferentiableImage):
     Naive RGB image representation
     """
 
-    def __init__(self, width, height, scale=1, device=DEVICE):
+    def __init__(self, width, height, scale=1, device=None):
         super().__init__(width * scale, height * scale)
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = device
         self.tensor = nn.Parameter(
             torch.zeros(1, 3, height, width).to(
-                device=device, memory_format=torch.channels_last
+                device=self.device, memory_format=torch.channels_last
             )
         )
         self.output_axes = ("n", "s", "y", "x")
@@ -42,7 +45,9 @@ class RGBImage(DifferentiableImage):
         self.tensor.set_(tensor.unsqueeze(0))
 
     @torch.no_grad()
-    def encode_image(self, pil_image, device=DEVICE, **kwargs):
+    def encode_image(self, pil_image, device, **kwargs):
+        if device is None:
+            device = self.device
         width, height = self.image_shape
         scale = self.scale
         pil_image = pil_image.resize((width // scale, height // scale), Image.LANCZOS)

--- a/src/pytti/image_models/vqgan.py
+++ b/src/pytti/image_models/vqgan.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from taming.models import cond_transformer, vqgan
 
-from pytti import DEVICE, replace_grad, clamp_with_grad, vram_usage_mode
+from pytti import replace_grad, clamp_with_grad, vram_usage_mode
 import torch
 from torch.nn import functional as F
 from pytti.image_models import EMAImage
@@ -134,7 +134,13 @@ class VQGANImage(EMAImage):
     """
 
     @vram_usage_mode("VQGAN Image")
-    def __init__(self, width, height, scale=1, model=VQGAN_MODEL, ema_val=0.99):
+    def __init__(
+        self, width, height, scale=1, model=VQGAN_MODEL, ema_val=0.99, device=None
+    ):
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = device
+
         if model is None:
             model = VQGAN_MODEL
             if model is None:
@@ -189,7 +195,9 @@ class VQGANImage(EMAImage):
             dummy.decay = self.decay
         return dummy
 
-    def get_latent_tensor(self, detach=False, device=DEVICE):
+    def get_latent_tensor(self, detach=False, device=None):
+        if device is None:
+            device = self.device
         z = self.tensor
         if detach:
             z = z.detach()
@@ -202,7 +210,9 @@ class VQGANImage(EMAImage):
 
         return LatentLoss
 
-    def decode(self, z, device=DEVICE):
+    def decode(self, z, device=None):
+        if device is None:
+            device = self.device
         z_q = vector_quantize(z, self.vqgan_quantize_embedding).movedim(3, 1).to(device)
         out = self.vqgan_decode(z_q).add(1).div(2)
         width, height = self.image_shape
@@ -210,7 +220,9 @@ class VQGANImage(EMAImage):
         # return F.interpolate(clamp_with_grad(out, 0, 1).to(device, memory_format = torch.channels_last), (height, width), mode='nearest')
 
     @torch.no_grad()
-    def encode_image(self, pil_image, device=DEVICE, **kwargs):
+    def encode_image(self, pil_image, device=None, **kwargs):
+        if device is None:
+            device = self.device
         pil_image = pil_image.resize(self.image_shape, Image.LANCZOS)
         pil_image = TF.to_tensor(pil_image)
         z, *_ = self.vqgan_encode(pil_image.unsqueeze(0).to(device) * 2 - 1)
@@ -218,7 +230,9 @@ class VQGANImage(EMAImage):
         self.reset()
 
     @torch.no_grad()
-    def make_latent(self, pil_image, device=DEVICE):
+    def make_latent(self, pil_image, device=None):
+        if device is None:
+            device = self.device
         pil_image = pil_image.resize(self.image_shape, Image.LANCZOS)
         pil_image = TF.to_tensor(pil_image)
         z, *_ = self.vqgan_encode(pil_image.unsqueeze(0).to(device) * 2 - 1)
@@ -234,7 +248,9 @@ class VQGANImage(EMAImage):
         self.tensor.set_(self.rand_latent())
         self.reset()
 
-    def rand_latent(self, device=DEVICE, vqgan_quantize_embedding=None):
+    def rand_latent(self, device=None, vqgan_quantize_embedding=None):
+        if device is None:
+            device = self.device
         if vqgan_quantize_embedding is None:
             vqgan_quantize_embedding = self.vqgan_quantize_embedding
         n_toks = self.n_toks
@@ -246,9 +262,13 @@ class VQGANImage(EMAImage):
         z = z.view([-1, toksY, toksX, self.e_dim])
         return z
 
+    # Why is this a static method? Make it a regular method and kill the globals.
     @staticmethod
-    def init_vqgan(model_name, model_artifacts_path, device=DEVICE):
-        global VQGAN_MODEL, VQGAN_NAME, VQGAN_IS_GUMBEL
+    def init_vqgan(model_name, model_artifacts_path, device=None):
+        if device is None:
+            # device = self.device
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        global VQGAN_MODEL, VQGAN_NAME, VQGAN_IS_GUMBEL  # uh.... fix this nonsense.
         if VQGAN_NAME == model_name:
             return
         if model_name not in VQGAN_MODEL_NAMES:

--- a/src/pytti/update_func.py
+++ b/src/pytti/update_func.py
@@ -277,6 +277,7 @@ def update(
                         border_mode=params.infill_mode,
                         sampling_mode=params.sampling_mode,
                         stabilize=params.lock_camera,
+                        device=None,
                     )
                     freeze_vram_usage()
 

--- a/src/pytti/update_func.py
+++ b/src/pytti/update_func.py
@@ -215,6 +215,14 @@ def update(
             if params.reset_lr_each_frame:
                 model.set_optim(None)
             if params.animation_mode == "2D":
+                logger.debug(params.translate_x)
+                logger.debug(params.translate_y)
+                logger.debug(params.rotate_2d)
+                logger.debug(params.zoom_x_2d)
+                logger.debug(params.zoom_y_2d)
+                from pytti.eval_tools import global_bands
+
+                logger.debug(global_bands)
                 tx, ty = parametric_eval(params.translate_x), parametric_eval(
                     params.translate_y
                 )
@@ -222,6 +230,10 @@ def update(
                 zx, zy = parametric_eval(params.zoom_x_2d), parametric_eval(
                     params.zoom_y_2d
                 )
+                logger.debug(f"Translate: {tx}, {ty}")
+                logger.debug(f"Rotate: {theta}")
+                logger.debug(f"Zoom: {zx}, {zy}")
+
                 next_step_pil = zoom_2d(
                     img,
                     (tx, ty),

--- a/src/pytti/workhorse.py
+++ b/src/pytti/workhorse.py
@@ -242,7 +242,7 @@ def _main(cfg: DictConfig):
         ###########################
 
         # load CLIP
-        load_clip(params)
+        load_clip(params, device=_device)
 
         cutn = params.cutouts
         if params.gradient_accumulation_steps > 1:
@@ -264,6 +264,7 @@ def _main(cfg: DictConfig):
             cut_pow=params.cut_pow,
             padding=params.cutout_border,
             border_mode=params.border_mode,
+            device=_device,
         )
 
         # load scenes

--- a/src/pytti/workhorse.py
+++ b/src/pytti/workhorse.py
@@ -189,6 +189,7 @@ def _main(cfg: DictConfig):
     params = cfg
 
     _device = params.get("device", "cuda:0")
+    logger.debug(f"Using device {_device}")
     torch.cuda.set_device(_device)
 
     # literal "off" in yaml interpreted as False
@@ -319,6 +320,7 @@ def _main(cfg: DictConfig):
                 gamma=params.gamma,
                 hdr_weight=params.hdr_weight,
                 norm_weight=params.palette_normalization_weight,
+                device=_device,
             )
             img.encode_random(random_pallet=params.random_initial_palette)
             if params.target_palette.strip() != "":
@@ -328,12 +330,16 @@ def _main(cfg: DictConfig):
             else:
                 img.lock_pallet(params.lock_palette)
         elif params.image_model == "Unlimited Palette":
-            img = RGBImage(params.width, params.height, params.pixel_size)
+            img = RGBImage(
+                params.width, params.height, params.pixel_size, device=_device
+            )
             img.encode_random()
         elif params.image_model == "VQGAN":
             model_artifacts_path = Path(params.models_parent_dir) / "vqgan"
             VQGANImage.init_vqgan(params.vqgan_model, model_artifacts_path)
-            img = VQGANImage(params.width, params.height, params.pixel_size)
+            img = VQGANImage(
+                params.width, params.height, params.pixel_size, device=_device
+            )
             img.encode_random()
         else:
             logger.critical(

--- a/src/pytti/workhorse.py
+++ b/src/pytti/workhorse.py
@@ -188,7 +188,11 @@ def _main(cfg: DictConfig):
     # params = OmegaConf.to_container(cfg, resolve=True)
     params = cfg
 
-    _device = params.get("device", "cuda:0")
+    if torch.cuda.is_available():
+        # _device = params.get("device", "cuda:0")
+        _device = params.get("device", 0)
+    else:
+        _device = params.get("device", "cpu")
     logger.debug(f"Using device {_device}")
     torch.cuda.set_device(_device)
 

--- a/src/pytti/workhorse.py
+++ b/src/pytti/workhorse.py
@@ -188,6 +188,9 @@ def _main(cfg: DictConfig):
     # params = OmegaConf.to_container(cfg, resolve=True)
     params = cfg
 
+    _device = params.get("device", "cuda:0")
+    torch.cuda.set_device(_device)
+
     # literal "off" in yaml interpreted as False
     if params.animation_mode == False:
         params.animation_mode = "off"

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -1,0 +1,66 @@
+import pytest
+
+from hydra import initialize, compose
+from loguru import logger
+from pytti.workhorse import _main as render_frames
+from omegaconf import OmegaConf, open_dict
+
+
+CONFIG_BASE_PATH = "config"
+CONFIG_DEFAULTS = "default.yaml"
+
+TEST_DEVICE = "cuda:1"
+
+
+def run_cfg(cfg_str):
+    with initialize(config_path=CONFIG_BASE_PATH):
+        cfg_base = compose(
+            config_name=CONFIG_DEFAULTS,
+            overrides=[f"conf=_empty"],
+        )
+        cfg_this = OmegaConf.create(cfg_str)
+
+        with open_dict(cfg_base) as cfg:
+            cfg = OmegaConf.merge(cfg_base, cfg_this)
+        render_frames(cfg)
+
+
+def test_mmc_device():
+    cfg_str = f"""# @package _global_
+scenes: a photograph of an apple
+use_mmc: true
+mmc_models:
+- architecture: clip
+  publisher: openai
+  id: RN50
+  #device: '{TEST_DEVICE}'
+device: '{TEST_DEVICE}'
+"""
+    run_cfg(cfg_str)
+
+
+def test_vqgan_device():
+    cfg_str = f"""# @package _global_
+scenes: a photograph of an apple
+image_model: VQGAN
+device: '{TEST_DEVICE}'
+"""
+    run_cfg(cfg_str)
+
+
+def test_depth_device():
+    cfg_str = f"""# @package _global_
+scenes: a photograph of an apple
+depth_stabilization_weight: 1
+device: '{TEST_DEVICE}'
+"""
+    run_cfg(cfg_str)
+
+
+def test_flow_device():
+    cfg_str = f"""# @package _global_
+scenes: a photograph of an apple
+flow_stabilization_weight: 1
+device: '{TEST_DEVICE}'
+"""
+    run_cfg(cfg_str)


### PR DESCRIPTION
closes #33 and #76 

for multi-gpu (prob gonna take a few PRs, should make an intermediary feature branch to PR into to keep it a bit cleaner.

to do:
* I expect there will be race conditions writing to images_out and backups (at least when hydra doesn't intercept outputs). maybe wontfix and users just need to be careful?
* create tensors on GPU when possible (rather than moving)
* tests that only run in the presence of multiple GPUs, or that otherwise can mock that.
  * https://docs.pytest.org/en/6.2.x/skipping.html#skipif

future:
* multi-gpu: data parallel
* multi-gpu: assign models/processes to separate GPUs
* multi-gpu: model parallel
  * https://pytorch.org/docs/stable/fsdp.html
